### PR TITLE
Fix post publish time to avoid Jekyll future-date skip

### DIFF
--- a/_posts/2026-04-14-multi-tenant-active-storage.md
+++ b/_posts/2026-04-14-multi-tenant-active-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Multi-Tenant Active Storage Done Right"
-date: 2026-04-14 00:00:00 -0600
+date: 2026-04-14 09:00:00 -0600
 last_modified_at: 2026-04-14 00:00:00 -0600
 categories: [development]
 tags: [rails, activestorage, s3, cloudflare, r2, multi-tenant, image-processing, doctors-journey]
@@ -9,7 +9,7 @@ tags: [rails, activestorage, s3, cloudflare, r2, multi-tenant, image-processing,
 
 ## The Starting Point
 
-The [Doctors app](/blog/upgrading-rails-from-5-to-8-seven-years/) — Asistencia Clínica — is a multi-tenant Rails 8.1 application. Each clinic gets its own subdomain: `demo.doctors.com`, `drasmith.doctors.com`, and so on. File storage goes to Cloudflare R2, which speaks the S3 API.
+The [Doctors app](/blog/upgrading-rails-from-5-to-8-seven-years/) — is a multi-tenant Rails 8.1 application. Each clinic gets its own subdomain: `demo.doctors.com`, `drasmith.doctors.com`, and so on. File storage goes to Cloudflare R2, which speaks the S3 API.
 
 The multi-tenant part means files from different clinics need to live under separate paths in the same bucket. A patient photo for the `demo` clinic should end up at `demo/attachments/user/42/<key>`, not mixed in with everyone else's files.
 

--- a/_posts/2026-04-14-multi-tenant-active-storage.md
+++ b/_posts/2026-04-14-multi-tenant-active-storage.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Multi-Tenant Active Storage Done Right"
 date: 2026-04-14 09:00:00 -0600
-last_modified_at: 2026-04-14 00:00:00 -0600
+last_modified_at: 2026-04-14 09:00:00 -0600
 categories: [development]
 tags: [rails, activestorage, s3, cloudflare, r2, multi-tenant, image-processing, doctors-journey]
 ---


### PR DESCRIPTION
## Summary
- Changed publish time from `00:00:00` to `09:00:00` for the multi-tenant Active Storage post
- Jekyll skipped building the post because `00:00:00 -0600` was still in the future when the CI build ran in UTC

## Test plan
- [x] Verify post appears at juanvasquez.dev/blog/multi-tenant-active-storage/ after deploy