### PR TITLE
Add post: contributing to MDN in your language

### DIFF
--- a/_posts/2026-09-30-finishing-a-60-page-mdn-localization-tracker.md
+++ b/_posts/2026-09-30-finishing-a-60-page-mdn-localization-tracker.md
@@ -1,0 +1,158 @@
+---
+layout: post
+title: "Finishing a 60-Page MDN Localization Tracker"
+date: 2026-09-30 10:00:00 -0600
+last_modified_at: 2026-09-30 10:00:00 -0600
+categories: [development]
+tags: [mdn, localization, open-source, spanish, contribution, documentation]
+---
+
+In August we closed [issue #35373](https://github.com/mdn/translated-content/issues/35373) in `mdn/translated-content`: the whole `/MDN/Writing_guidelines` section, 60 documents, synchronized with the English source. It took 114 days and 62 merged pull requests, spread across a handful of volunteers working in their spare time.
+
+This post is about what actually makes that kind of tracker finishable, and about the things I got wrong along the way.
+
+---
+
+## Checkboxes Lie
+
+The issue had 58 subtasks, one per document, all checked. My first instinct was to read that as "done."
+
+It isn't. A checklist is a snapshot of the day the subtasks were generated. It does not grow when new English pages land upstream. Two pages (`howto/retiring_content` and `retired_content`) were created in `mdn/content` on May 11, three weeks after we split the parent issue on April 20. They had no subtask, no checkbox, and no one was tracking them.
+
+The reliable check compares directories, not checkboxes:
+
+```sh
+comm -23 <(cd content/files/en-us/mdn/writing_guidelines && find . -name index.md | sort) \
+         <(cd translated-content/files/es/mdn/writing_guidelines && find . -name index.md | sort)
+```
+
+Empty output means every English page has a Spanish counterpart. Run it the other way around too (`comm -13`) to catch Spanish pages whose English source was moved or deleted, which leaves you with orphan translations at a slug nobody links to.
+
+When that command finally printed nothing in both directions, that was the real "done" signal. The two missing pages became subtasks #37427 and #37428, and their PRs merged on the last day of the project.
+
+---
+
+## `sourceCommit` Is the Ledger
+
+Every translated MDN page carries a front matter field:
+
+```yaml
+---
+title: Contenido retirado
+slug: MDN/Writing_guidelines/Howto/Retiring_content/Retired_content
+l10n:
+  sourceCommit: ca0b474bb2e153ce72718cb304306e540065a888
+---
+```
+
+That SHA is the commit of the English file the translation was based on. It is the difference between a section you can maintain and a section you have to re-read in full every time.
+
+The check is one API call per page:
+
+```sh
+gh api "repos/mdn/content/commits?path=files/en-us/<path>/index.md&per_page=1" --jq '.[0].sha'
+```
+
+Compare it against the tracked value. Ten of our 60 pages were behind. That sounds alarming until you look at what actually changed upstream: `fulfil` → `fulfill`, `a HTTP` → `an HTTP`, a CC0 link update, a few spelling-bot commits. English-only chores with no Spanish counterpart.
+
+So the closing PR moved ten SHAs and changed nothing else. Ten lines. The value isn't in those lines, it's in what they prevent: the next person running a staleness check gets a clean report instead of ten false positives they have to investigate one by one.
+
+---
+
+## Verify the Upstream "Fix" Before You Copy It
+
+One of those ten upstream commits rewrote a GitHub docs URL in `howto/images_media`. I dutifully copied the change into the Spanish page, then ran the link check out of habit:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}' -L "https://docs.github.com/en/pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"
+# 404
+
+curl -s -o /dev/null -w '%{http_code}' -L "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"
+# 200
+```
+
+The "fixed" URL is the broken one. The Spanish page already had the working link, and my sync would have replaced a working link with a dead one, in the name of matching the source.
+
+The source of truth is the source of truth for *content*, not for *facts*. Links rot in English too. It cost me one `curl` to find out.
+
+---
+
+## The Fallback That Doesn't Exist
+
+Our Spanish contributor guide told people that MDN renders English content as a fallback when a page isn't translated, and the entire anchor-linking section was built on that claim. It's how I explained `/es/` links to newcomers for months.
+
+It's false:
+
+| URL | Spanish file exists | HTTP |
+|---|---|---|
+| `/es/docs/Learn_web_development/Core/Scripting/Functions` | no | 404 |
+| `/es/docs/MDN/Writing_guidelines/Howto/Retiring_content` | no | 404 |
+| `/es/docs/Web/API/Fetch_API` | yes | 200 |
+
+There is no whole-page fallback. A `/es/` URL with no translated file is a 404 until someone translates it.
+
+The rule the claim supported ("always use `/es/` in internal links") is still right, just for a different reason: locale consistency, and the link starts working the moment the target gets translated. But the anchor advice that followed from it was actively wrong. We were telling translators to keep the English fragment (`#browser_compatibility`) on links to untranslated pages "because MDN will serve English there." It won't. There is no page.
+
+The corrected advice: if the target page is translated, use the translated heading id. If it isn't, drop the fragment and keep the page link. A fragment that matches nothing just dumps the reader at the top of the page.
+
+I opened a PR to fix the guide. Worth remembering that a wrong sentence in a contributor guide doesn't produce one bug, it produces one bug per contributor who reads it.
+
+---
+
+## Small Rules That Show Up in Every Review
+
+Four patterns came up often enough during this project that they're now part of my review checklist:
+
+**API names keep English word order.** `Canvas API`, not "API Canvas." Spanish adjective order wants to flip it, and it reads natural, but the name is a proper noun. The article goes in front of the whole thing: *la Canvas API quedó obsoleta*.
+
+**Callout keywords stay in English.** `> [!NOTE]` renders as a styled box; `> [!Nota]` renders as a plain blockquote. The label is localized by the build, not by you.
+
+**Images don't get copied into `files/es/`.** If the Spanish page references an image that only exists in the English folder, the build rewrites the `src` to the `/en-US/` path automatically. Copying the binary in means a file that can't be diffed, gets duplicated in every commit that touches it, and silently drifts when the English one is updated. Only genuinely locale-specific images (a screenshot of a Spanish UI) belong there.
+
+**Local tooling disagrees with CI.** My local `prettier` was 3.8.3, CI runs 3.9.4, and they format markdown blockquotes differently. My pre-commit hook helpfully "fixed" two files, adding lines CI never asked for. The tell: run the same check against the *untouched English source*. If it complains there too, it's your tooling, not the file.
+
+---
+
+## The Part That Isn't Technical
+
+The most expensive mistake of this project had nothing to do with markdown.
+
+Two contributors translated the same two pages. I opened PRs for `Retiring_content` and `Retired_content` on July 31. Another contributor opened PRs for the same two files on August 6, having done the whole translation from scratch. Neither of us knew.
+
+That's someone's evening spent on work that can't merge, and it's on the maintainers, not on them. The subtasks existed. What didn't exist was a visible reservation on them at the moment they started.
+
+The convention we use is "comment on the subtask to claim it," and it works when people know about it, which means it has to be in the issue body, in the review replies, and in the welcome message for first-time contributors, every single time. Repeating it feels redundant right up until it isn't.
+
+---
+
+## The Numbers
+
+| | |
+|---|---|
+| Started | April 20, 2026 |
+| Finished | August 12, 2026 |
+| Duration | 114 days (16 weeks) |
+| Documents | 60 |
+| Subtasks | 60 (58 planned + 2 that appeared later) |
+| Merged PRs | 62 |
+| Pace | ~1 page every 2 days |
+
+Four months for 60 pages is not fast. But the number I care about is that the pace never went to zero: not one of those 16 weeks passed without something merging. That's the hard part of a volunteer localization project. Starting is easy. Week 11 is where these things die.
+
+Most of the credit belongs to [Mario Morillo](https://github.com/mariomorillo), who merged 37 of those PRs and reviewed nearly everything else.
+
+---
+
+## What Made It Repeatable
+
+The thing that outlasts the issue is the shape of the work:
+
+1. **One page per subtask.** Not "sync the section." A newcomer can look at a subtask and know whether they can finish it tonight.
+2. **Sort subtasks shortest to longest.** The first one being 116 lines instead of 900 is the difference between someone starting and someone closing the tab.
+3. **Put the homework in the subtask.** English source path, target file, line count, tracked SHA vs latest SHA, and the differences already detected. Nobody should have to investigate before they can translate.
+4. **Verify by filesystem, not by checkbox.** Covered above, and it's the one that caught the two missing pages.
+5. **Bump `sourceCommit` when you close.** Otherwise the next sync starts from zero again, which is exactly how this section ended up needing a 60-page tracker in the first place.
+
+That flow is now running on [issue #9638](https://github.com/mdn/translated-content/issues/9638), which is bigger: 43 open subtasks across the Learn Web Development section, sorted shortest-first, each with its sync status precomputed.
+
+If you read Spanish and want a first open source contribution with a genuinely well-scoped task waiting for you, that's the issue. Comment on a subtask to claim it, and open your PR with `Fixes #<subtask>`, not the parent, so the rest stay open. The [Spanish localization guide](https://github.com/mdn/translated-content/blob/main/docs/es/README.md) is the place to start.

--- a/_posts/2026-09-30-finishing-a-60-page-mdn-localization-tracker.md
+++ b/_posts/2026-09-30-finishing-a-60-page-mdn-localization-tracker.md
@@ -7,7 +7,7 @@ categories: [development]
 tags: [mdn, localization, open-source, spanish, contribution, documentation]
 ---
 
-In August we closed [issue #35373](https://github.com/mdn/translated-content/issues/35373) in `mdn/translated-content`: the whole `/MDN/Writing_guidelines` section, 60 documents, synchronized with the English source. It took 114 days and 62 merged pull requests, spread across a handful of volunteers working in their spare time.
+In August I closed [issue #35373](https://github.com/mdn/translated-content/issues/35373) in `mdn/translated-content`: the whole `/MDN/Writing_guidelines` section, 60 documents, synchronized with the English source. It took 114 days and 62 merged pull requests, spread across a handful of volunteers working in their spare time. I maintain the Spanish locale, so I split the issue, reviewed most of the PRs, and translated some of the pages myself.
 
 This post is about what actually makes that kind of tracker finishable, and about the things I got wrong along the way.
 
@@ -17,7 +17,7 @@ This post is about what actually makes that kind of tracker finishable, and abou
 
 The issue had 58 subtasks, one per document, all checked. My first instinct was to read that as "done."
 
-It isn't. A checklist is a snapshot of the day the subtasks were generated. It does not grow when new English pages land upstream. Two pages (`howto/retiring_content` and `retired_content`) were created in `mdn/content` on May 11, three weeks after we split the parent issue on April 20. They had no subtask, no checkbox, and no one was tracking them.
+It isn't. A checklist is a snapshot of the day the subtasks were generated. It does not grow when new English pages land upstream. Two pages (`howto/retiring_content` and `retired_content`) were created in `mdn/content` on May 11, three weeks after I split the parent issue on April 20. They had no subtask, no checkbox, and no one was tracking them.
 
 The reliable check compares directories, not checkboxes:
 
@@ -79,7 +79,7 @@ The source of truth is the source of truth for *content*, not for *facts*. Links
 
 ## The Fallback That Doesn't Exist
 
-Our Spanish contributor guide told people that MDN renders English content as a fallback when a page isn't translated, and the entire anchor-linking section was built on that claim. It's how I explained `/es/` links to newcomers for months.
+The Spanish contributor guide told people that MDN renders English content as a fallback when a page isn't translated, and the entire anchor-linking section was built on that claim. It's how I explained `/es/` links to newcomers for months.
 
 It's false:
 
@@ -91,7 +91,7 @@ It's false:
 
 There is no whole-page fallback. A `/es/` URL with no translated file is a 404 until someone translates it.
 
-The rule the claim supported ("always use `/es/` in internal links") is still right, just for a different reason: locale consistency, and the link starts working the moment the target gets translated. But the anchor advice that followed from it was actively wrong. We were telling translators to keep the English fragment (`#browser_compatibility`) on links to untranslated pages "because MDN will serve English there." It won't. There is no page.
+The rule the claim supported ("always use `/es/` in internal links") is still right, just for a different reason: locale consistency, and the link starts working the moment the target gets translated. But the anchor advice that followed from it was actively wrong. I had been telling translators to keep the English fragment (`#browser_compatibility`) on links to untranslated pages "because MDN will serve English there." It won't. There is no page.
 
 The corrected advice: if the target page is translated, use the translated heading id. If it isn't, drop the fragment and keep the page link. A fragment that matches nothing just dumps the reader at the top of the page.
 
@@ -121,7 +121,7 @@ Two contributors translated the same two pages. I opened PRs for `Retiring_conte
 
 That's someone's evening spent on work that can't merge, and it's on the maintainers, not on them. The subtasks existed. What didn't exist was a visible reservation on them at the moment they started.
 
-The convention we use is "comment on the subtask to claim it," and it works when people know about it, which means it has to be in the issue body, in the review replies, and in the welcome message for first-time contributors, every single time. Repeating it feels redundant right up until it isn't.
+The convention is "comment on the subtask to claim it," and it works when people know about it, which means it has to be in the issue body, in the review replies, and in the welcome message for first-time contributors, every single time. Repeating it feels redundant right up until it isn't.
 
 ---
 
@@ -156,3 +156,11 @@ The thing that outlasts the issue is the shape of the work:
 That flow is now running on [issue #9638](https://github.com/mdn/translated-content/issues/9638), which is bigger: 43 open subtasks across the Learn Web Development section, sorted shortest-first, each with its sync status precomputed.
 
 If you read Spanish and want a first open source contribution with a genuinely well-scoped task waiting for you, that's the issue. Comment on a subtask to claim it, and open your PR with `Fixes #<subtask>`, not the parent, so the rest stay open. The [Spanish localization guide](https://github.com/mdn/translated-content/blob/main/docs/es/README.md) is the place to start.
+
+---
+
+## Links
+
+[Issue #35373](https://github.com/mdn/translated-content/issues/35373) — the tracker this post is about
+[Issue #9638](https://github.com/mdn/translated-content/issues/9638) — the next one, 43 subtasks open
+[Spanish localization guide](https://github.com/mdn/translated-content/blob/main/docs/es/README.md) — start here

--- a/_posts/2026-10-07-contributing-to-mdn-in-your-language.md
+++ b/_posts/2026-10-07-contributing-to-mdn-in-your-language.md
@@ -1,0 +1,112 @@
+---
+layout: post
+title: "Contributing to MDN in Your Language"
+date: 2026-10-07 10:00:00 -0600
+last_modified_at: 2026-10-07 10:00:00 -0600
+categories: [development]
+tags: [mdn, localization, open-source, documentation, contribution, community]
+---
+
+A developer in Guadalajara opens MDN to look up how `fetch` handles errors. They read English fine, but it is their third language, and after nine hours of work it is the difference between understanding a page and getting through it. They switch to `/es/`, and the page is there, current, complete.
+
+That is the whole product. Everything else in this post is logistics.
+
+I maintain the Spanish locale of [mdn/translated-content](https://github.com/mdn/translated-content). This is what I wish someone had told me before my first PR, written for whatever language you speak.
+
+---
+
+## It Is Smaller Than You Think
+
+MDN has eight active locales: Spanish, French, Japanese, Korean, Brazilian Portuguese, Russian, and both Chinese variants. Every one of them is maintained by a volunteer team, and the teams are small — two people for French, three for Spanish and Brazilian Portuguese, five or six for the larger ones.
+
+That is the entire staff standing between a documentation site used by millions of developers and eight languages' worth of drift.
+
+I bring this up because "contributing to MDN" sounds like joining something enormous where your one page won't matter. The opposite is true. If you translate one page today, you are a measurable fraction of this month's output for your language. There is no queue of people ahead of you.
+
+---
+
+## What a Contribution Actually Looks Like
+
+Not a rewrite of the site. One file.
+
+You find a page in your language that is missing or out of date, compare it to the English source, translate or update it, and open a pull request. A short page is an evening. A long guide is a weekend. Both are complete, mergeable contributions.
+
+The thing that trips people up is scope, in both directions. Some contributors open a PR fixing one typo on a page that is two years out of date — welcome, but the page stays broken. Others try to sync an entire section at once and burn out on page four.
+
+The unit that works is **one page, fully done**. MDN's shared guidelines are explicit about this: do not partially translate a document. A page that is half in your language and half in English is worse than one that is fully English, because the reader can't tell which parts they can trust.
+
+---
+
+## The Ledger That Makes It Sustainable
+
+Every translated page carries this in its front matter:
+
+```yaml
+l10n:
+  sourceCommit: ca0b474bb2e153ce72718cb304306e540065a888
+```
+
+That is the commit of the English file your translation was based on. It looks like bookkeeping. It is actually the single thing that decides whether a locale is maintainable or not.
+
+With it, the next contributor asks a cheap question: what changed in English since that commit? Usually the answer is a typo fix and they can move on. Without it, the only way to know whether a page is current is to read both versions in full, in every language, forever. That is how locales quietly die — not from lack of translators, but from every update costing a full re-read.
+
+So when you finish a page, set that SHA to the latest commit of the English source. You are not doing it for yourself. You are doing it for whoever touches the page in two years.
+
+---
+
+## What English-Only Contributors Get Wrong (Including Me)
+
+A few things I learned by getting them wrong in Spanish, which apply to any locale:
+
+**Translating the page is not the same as translating the links.** If you translate a heading, its anchor id changes with it. Every link pointing at the old English fragment now silently drops readers at the top of the page instead of the section you promised them. Nothing errors. Nothing fails CI. It just quietly doesn't work.
+
+**Don't reason about how the site renders — check.** Heading ids, live-sample names, image paths: fetch the rendered page and look. Any MDN URL with `/index.json` appended returns the rendered body, which is the fastest way to see real heading ids without building anything locally.
+
+**Proper nouns don't get grammar.** `Canvas API` stays `Canvas API` even when your language wants to reorder the words. Same for callout keywords like `[!NOTE]`, which the build localizes for you and which stop rendering as callouts the moment you translate them.
+
+**Your local tooling is not CI's tooling.** When a formatter complains, run it against the untouched English source first. If it complains there too, the problem is your version, not your file.
+
+None of these are in a style guide because they are not style. They are the failure modes you only meet by shipping.
+
+---
+
+## Where the Real Notes Live
+
+This took me embarrassingly long to map out, so here it is in one place:
+
+- **[`docs/README.md`](https://github.com/mdn/translated-content/blob/main/docs/README.md)** — the cross-locale rules. Short. Front matter, no machine translation, no partial translations, how to handle code blocks. Read this first, whatever your language.
+- **Your locale's guide** — linked from that same file. Depth varies a lot; Spanish and Simplified Chinese are the longest, and some locales have barely a page. If yours is thin, that itself is a contribution waiting.
+- **[`PEERS_GUIDELINES.md`](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md)** — the one most people never find. It names every locale's review team, member by member, and states what those maintainers committed to: review every PR within two weeks, triage issues within a month. It is who to ping, and what you can expect from them.
+- **The `l10n-<locale>` labels** — `l10n-es`, `l10n-fr`, `l10n-ja`, `l10n-ko`, `l10n-pt-br`, `l10n-ru`, `l10n-zh`. This is your locale's open work.
+- **[MDN community discussions](https://github.com/orgs/mdn/discussions)** and the MDN Discord, where most locales have a channel.
+
+---
+
+## Picking Your First Page
+
+Filter issues by your locale's label and look for something scoped to a single document. In Spanish we structure work that way deliberately: a tracking issue gets split into one subtask per page, each carrying the English source path, the line count, the current sync status, and the differences already detected. You reserve one by commenting on it, and you open your PR against that subtask, not the parent.
+
+If your locale doesn't work that way, the same trick works solo. Pick one page you personally use. Compare it to the English source. If it's stale, that's your PR.
+
+Then comment before you start. This is the part I underestimated: I once spent an evening translating two pages that another contributor had already translated, and neither of us knew until both PRs were open. That is nobody's fault except the maintainer's — mine — for not making claims visible. A one-line comment costs nothing and protects someone's evening.
+
+---
+
+## What I Learned
+
+The thing that surprised me most about locale maintenance is how little of it is translation.
+
+It's noticing that a guide has been telling contributors something false for months. It's checking whether an anchor actually resolves instead of assuming. It's writing the reservation convention in the issue body, the review reply, and the welcome message, because saying it once means half the people never see it. It's replying to a first PR in a way that makes someone want to open a second one.
+
+Translation is the easy part. Making it repeatable, so a language doesn't fall behind again the moment one person gets busy, is the actual work — and it's work that doesn't require being a senior engineer. It requires caring that the page is right.
+
+If you speak a language MDN supports, your locale team is two to six people and they are behind. That is not a discouraging fact. It means the thing you do this weekend is visible, and the developer who lands on that page next month has no idea you exist, but their day goes slightly better.
+
+---
+
+## Links
+
+[mdn/translated-content](https://github.com/mdn/translated-content) — the repo
+[Cross-locale guidelines](https://github.com/mdn/translated-content/blob/main/docs/README.md) — start here
+[Peer guidelines](https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md) — review teams per locale
+[Translated content on MDN](https://developer.mozilla.org/en-US/docs/MDN/Community/Contributing/Translated_content) — the official contributor page


### PR DESCRIPTION
Second MDN post, general rather than Spanish-specific: a friendly on-ramp for contributing to `mdn/translated-content` in any language, built on what the Spanish locale work taught me.

**Scheduled for 2026-10-07**, the Wednesday after the Spanish-locale post.

Leads with what translated docs mean for a reader, not with project stats. Covers how small the locale teams actually are, what one contribution looks like (one page, fully done), why `l10n.sourceCommit` decides whether a locale stays maintainable, four failure modes that generalize across locales, and — the part that's genuinely hard to find — where the real notes live: `docs/README.md`, per-locale guides, `PEERS_GUIDELINES.md` with the review team per locale, and the `l10n-*` labels.

Ends on the reservation lesson from the duplicate-work incident, framed as a maintainer failure.

Validation: `jekyll build --future` renders it; `htmlproofer` passes on all files.

Note: the MDN community discussions link points at `github.com/orgs/mdn/discussions`. Discussions are disabled on `mdn/translated-content` itself, so the repo-level link commonly shared for it is dead.
